### PR TITLE
Dense correspondence

### DIFF
--- a/libs/mve/depthmap.cc
+++ b/libs/mve/depthmap.cc
@@ -318,9 +318,11 @@ depthmap_triangulate (FloatImage::ConstPtr dm, math::Matrix3f const& invproj,
 }
 
 /* ---------------------------------------------------------------- */
+
 TriangleMesh::Ptr
 depthmap_triangulate (FloatImage::ConstPtr dm, ByteImage::ConstPtr ci,
-    math::Matrix3f const& invproj, float dd_factor)
+    math::Matrix3f const& invproj, float dd_factor,
+    mve::Image<unsigned int>* vertex_ids)
 {
     if (dm == nullptr)
         throw std::invalid_argument("Null depthmap given");
@@ -363,6 +365,10 @@ depthmap_triangulate (FloatImage::ConstPtr dm, ByteImage::ConstPtr ci,
         colors[vids[i]] = color / 255.0f;
     }
 
+    /* Provide the vertex ID mapping if requested. */
+    if (vertex_ids != nullptr)
+        std::swap(vids, *vertex_ids);
+
     return mesh;
 }
 
@@ -370,7 +376,8 @@ depthmap_triangulate (FloatImage::ConstPtr dm, ByteImage::ConstPtr ci,
 
 TriangleMesh::Ptr
 depthmap_triangulate (FloatImage::ConstPtr dm, ByteImage::ConstPtr ci,
-    CameraInfo const& cam, float dd_factor)
+    CameraInfo const& cam, float dd_factor,
+    mve::Image<unsigned int>* vertex_ids)
 {
     if (dm == nullptr)
         throw std::invalid_argument("Null depthmap given");
@@ -381,7 +388,7 @@ depthmap_triangulate (FloatImage::ConstPtr dm, ByteImage::ConstPtr ci,
     math::Matrix3f invproj;
     cam.fill_inverse_calibration(*invproj, dm->width(), dm->height());
     mve::TriangleMesh::Ptr mesh;
-    mesh = mve::geom::depthmap_triangulate(dm, ci, invproj, dd_factor);
+    mesh = mve::geom::depthmap_triangulate(dm, ci, invproj, dd_factor, vertex_ids);
 
     /* Transform mesh to world coordinates. */
     math::Matrix4f ctw;

--- a/libs/mve/depthmap.h
+++ b/libs/mve/depthmap.h
@@ -109,19 +109,23 @@ depthmap_triangulate (FloatImage::ConstPtr dm, math::Matrix3f const& invproj,
  * A helper function that triangulates the given depth map with optional
  * color image (which generates additional per-vertex colors) in local
  * image coordinates.
+ * If vertex_ids != nullptr, pixel-vertex_ID mapping is provided.
  */
 TriangleMesh::Ptr
 depthmap_triangulate (FloatImage::ConstPtr dm, ByteImage::ConstPtr ci,
-    math::Matrix3f const& invproj, float dd_factor = 5.0f);
+    math::Matrix3f const& invproj, float dd_factor = 5.0f, 
+    mve::Image<unsigned int>* vertex_ids = nullptr);
 
 /**
  * A helper function that triangulates the given depth map with optional
  * color image (which generates additional per-vertex colors) and transforms
  * the mesh into the global coordinate system.
+ * If vertex_ids != nullptr, pixel-vertex_ID mapping is provided.
  */
 TriangleMesh::Ptr
 depthmap_triangulate (FloatImage::ConstPtr dm, ByteImage::ConstPtr ci,
-    CameraInfo const& cam, float dd_factor = 5.0f);
+    CameraInfo const& cam, float dd_factor = 5.0f,
+    mve::Image<unsigned int>* vertex_ids = nullptr);
 
 /**
  * Algorithm to triangulate range grids.

--- a/libs/mve/depthmap.h
+++ b/libs/mve/depthmap.h
@@ -71,6 +71,8 @@ MVE_NAMESPACE_END
 MVE_NAMESPACE_BEGIN
 MVE_GEOM_NAMESPACE_BEGIN
 
+const float dd_factor_default = 5.0f;
+
 /**
  * Function that calculates the pixel footprint (pixel width)
  * in 3D coordinates for pixel (x,y) and 'depth' for a depth map
@@ -103,7 +105,7 @@ pixel_3dpos (std::size_t x, std::size_t y, float depth,
  */
 TriangleMesh::Ptr
 depthmap_triangulate (FloatImage::ConstPtr dm, math::Matrix3f const& invproj,
-    float dd_factor = 5.0f, mve::Image<unsigned int>* vids = nullptr);
+    float dd_factor = dd_factor_default, mve::Image<unsigned int>* vids = nullptr);
 
 /**
  * A helper function that triangulates the given depth map with optional
@@ -113,7 +115,7 @@ depthmap_triangulate (FloatImage::ConstPtr dm, math::Matrix3f const& invproj,
  */
 TriangleMesh::Ptr
 depthmap_triangulate (FloatImage::ConstPtr dm, ByteImage::ConstPtr ci,
-    math::Matrix3f const& invproj, float dd_factor = 5.0f, 
+    math::Matrix3f const& invproj, float dd_factor = dd_factor_default, 
     mve::Image<unsigned int>* vertex_ids = nullptr);
 
 /**
@@ -124,7 +126,7 @@ depthmap_triangulate (FloatImage::ConstPtr dm, ByteImage::ConstPtr ci,
  */
 TriangleMesh::Ptr
 depthmap_triangulate (FloatImage::ConstPtr dm, ByteImage::ConstPtr ci,
-    CameraInfo const& cam, float dd_factor = 5.0f,
+    CameraInfo const& cam, float dd_factor = dd_factor_default,
     mve::Image<unsigned int>* vertex_ids = nullptr);
 
 /**


### PR DESCRIPTION
1. mve::geom::depthmap_triangulate was modified to support an option of outputting the "vertex-IDs" image.
2. scene2pset was modified to support an option of outputting dense 2D-3D correspondence data.