### PR TITLE
Add methods to read tiff headers from files

### DIFF
--- a/libs/mve/image_io.cc
+++ b/libs/mve/image_io.cc
@@ -122,6 +122,13 @@ load_file_headers (std::string const& filename)
         catch (util::Exception&) {}
 #endif
 
+#ifndef MVE_NO_TIFF_SUPPORT
+      try
+      { return load_tiff_file_headers(filename); }
+      catch (util::FileException&) { throw; }
+      catch (util::Exception&) {}
+#endif
+
         try
         { return load_mvei_file_headers(filename); }
         catch (util::FileException&) { throw; }
@@ -678,6 +685,28 @@ load_tiff_file (std::string const& filename)
         TIFFClose(tif);
         throw;
     }
+}
+
+ImageHeaders
+load_tiff_file_headers (std::string const& filename)
+{
+    uint32 tiff_width, tiff_height, tiff_channels;
+    TIFF* tif = TIFFOpen(filename.c_str(), "r");
+    if (!tif) {
+        throw util::FileException(filename, std::strerror(errno));
+    }
+    TIFFGetField(tif, TIFFTAG_IMAGEWIDTH, &tiff_width);
+    TIFFGetField(tif, TIFFTAG_IMAGELENGTH, &tiff_height);
+    TIFFGetField(tif, TIFFTAG_SAMPLESPERPIXEL, &tiff_channels);
+    TIFFClose(tif);
+
+    /* Set TIFF header info. */
+    ImageHeaders headers;
+    headers.width = int(tiff_width);
+    headers.height = int(tiff_height);
+    headers.channels = int(tiff_channels);
+
+    return headers;
 }
 
 void

--- a/libs/mve/image_io.h
+++ b/libs/mve/image_io.h
@@ -162,6 +162,13 @@ ByteImage::Ptr
 load_tiff_file (std::string const& filename);
 
 /**
+ * Loads TIFF file headers only.
+ * May throw util::FileException and util::Exception.
+ */
+ImageHeaders
+load_tiff_file_headers (std::string const& filename);
+
+/**
  * Writes a TIFF to file. Supports any number of channels.
  * May throw util::FileException and util::Exception.
  */


### PR DESCRIPTION
This adds tiff header handling which for some unknown reason is missing.  Actual tiff file loading is already there and works.  MVS Texturing already supports TIF images in scene reconstruction, but the scene method requires proper header handling.  So these changes fix MVS texturing scene methods using TIF images.